### PR TITLE
Update chart and app versions to 2.1.0

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="224fa381-1c18-4902-adaa-46e4f7c0975f" name="Changes" comment="" />
+    <list default="true" id="224fa381-1c18-4902-adaa-46e4f7c0975f" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -127,7 +129,7 @@
       <workItem from="1746722606252" duration="653000" />
       <workItem from="1747823799729" duration="1947000" />
       <workItem from="1751366259870" duration="1340000" />
-      <workItem from="1752505121911" duration="631000" />
+      <workItem from="1752505121911" duration="1727000" />
     </task>
     <task id="LOCAL-00001" summary="cronjob - fix schedule quoting&#10;docs - use helm-docs utility to generate chart readme">
       <option name="closed" value="true" />
@@ -409,7 +411,15 @@
       <option name="project" value="LOCAL" />
       <updated>1752505641146</updated>
     </task>
-    <option name="localTasksCounter" value="36" />
+    <task id="LOCAL-00036" summary="Adds read permissions to GitHub workflows.">
+      <option name="closed" value="true" />
+      <created>1752505859270</created>
+      <option name="number" value="00036" />
+      <option name="presentableId" value="LOCAL-00036" />
+      <option name="project" value="LOCAL" />
+      <updated>1752505859270</updated>
+    </task>
+    <option name="localTasksCounter" value="37" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -419,8 +429,6 @@
   <component name="UnityProjectConfiguration" hasMinimizedUI="false" />
   <component name="VcsManagerConfiguration">
     <option name="CLEAR_INITIAL_COMMIT_MESSAGE" value="true" />
-    <MESSAGE value="Adds container environment variables to CronJob chart." />
-    <MESSAGE value="init, ci" />
     <MESSAGE value="Initializes Git submodules before Helm setup." />
     <MESSAGE value="Adds submodule checkout with token and recursive init." />
     <MESSAGE value="Fixes relative path to harbor-container-webhook chart." />
@@ -438,13 +446,15 @@
     <MESSAGE value="Release" />
     <MESSAGE value="Release WebApp chart version 2.0.0&#10;" />
     <MESSAGE value="Release WebApp chart version 2.0.0" />
-    <MESSAGE value="Adds" />
     <MESSAGE value="Adds imagePullSecrets configuration to migration job.&#10;" />
     <MESSAGE value="add line break on image pull secrets in migration job" />
     <MESSAGE value="B" />
     <MESSAGE value="Bumps chart and app version to 2.0.2.&#10;" />
     <MESSAGE value="Bumps chart and app version to 2.0.2." />
-    <option name="LAST_COMMIT_MESSAGE" value="Bumps chart and app version to 2.0.2." />
+    <MESSAGE value="Adds" />
+    <MESSAGE value="Adds read permissions to GitHub workflows.&#10;" />
+    <MESSAGE value="Adds read permissions to GitHub workflows." />
+    <option name="LAST_COMMIT_MESSAGE" value="Adds read permissions to GitHub workflows." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.2"
+appVersion: "2.1.0"
 
 icon: https://cncf-branding.netlify.app/img/projects/helm/icon/color/helm-icon-color.png

--- a/charts/webapp/templates/migration-job.yaml
+++ b/charts/webapp/templates/migration-job.yaml
@@ -26,6 +26,7 @@ spec:
         {{- include "WebAppMigrations.labels" . | nindent 8 }}
 
     spec:
+      serviceAccountName: {{ include "WebApp.serviceAccountName" . | lower }}
       {{- with .Values.imagePullSecrets | default }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Add missing service account name in migrations job

## Summary by Sourcery

Update Helm chart and application versions to 2.1.0 and include the missing service account name in the migrations job

Enhancements:
- Bump chart and appVersion to 2.1.0 in Chart.yaml
- Add serviceAccountName to the migrations Job template