### PR TITLE
Uses `app.kubernetes.io/part-of` label instead of `app.k8s.io`.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="224fa381-1c18-4902-adaa-46e4f7c0975f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.github/workflows/build-publish.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/build-publish.yml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/charts/innago-vault-k8s-role-operator/Chart.lock" beforeDir="false" afterPath="$PROJECT_DIR$/charts/innago-vault-k8s-role-operator/Chart.lock" afterDir="false" />
+    <list default="true" id="224fa381-1c18-4902-adaa-46e4f7c0975f" name="Changes" comment="Uses `app.kubernetes.io/part-of` label instead of `app.k8s.io`.">
+      <change beforePath="$PROJECT_DIR$/charts/innago-vault-k8s-role-operator/templates/cluster-role-binding.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/charts/innago-vault-k8s-role-operator/templates/cluster-role-binding.yaml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/charts/innago-vault-k8s-role-operator/templates/cluster-role.yaml" beforeDir="false" afterPath="$PROJECT_DIR$/charts/innago-vault-k8s-role-operator/templates/cluster-role.yaml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -150,7 +149,7 @@
       <workItem from="1753907035651" duration="33000" />
       <workItem from="1755839886956" duration="3861000" />
       <workItem from="1755852588980" duration="2447000" />
-      <workItem from="1756097072597" duration="3811000" />
+      <workItem from="1756097072597" duration="4508000" />
     </task>
     <task id="LOCAL-00001" summary="cronjob - fix schedule quoting&#10;docs - use helm-docs utility to generate chart readme">
       <option name="closed" value="true" />
@@ -456,7 +455,15 @@
       <option name="project" value="LOCAL" />
       <updated>1756099148177</updated>
     </task>
-    <option name="localTasksCounter" value="39" />
+    <task id="LOCAL-00039" summary="Updates dependency handling in CI and adds Vault Role Operator chart.">
+      <option name="closed" value="true" />
+      <created>1756101579375</created>
+      <option name="number" value="00039" />
+      <option name="presentableId" value="LOCAL-00039" />
+      <option name="project" value="LOCAL" />
+      <updated>1756101579375</updated>
+    </task>
+    <option name="localTasksCounter" value="40" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -466,14 +473,6 @@
   <component name="UnityProjectConfiguration" hasMinimizedUI="false" />
   <component name="VcsManagerConfiguration">
     <option name="CLEAR_INITIAL_COMMIT_MESSAGE" value="true" />
-    <MESSAGE value="Publishes Helm charts to GHCR using OCI." />
-    <MESSAGE value="Adds pages_branch and skip_existing to helm-docs action." />
-    <MESSAGE value="Adds write permissions for packages, ID token, and pages." />
-    <MESSAGE value="Moves GHCR login step before chart-releaser execution." />
-    <MESSAGE value="Removes skip_upload and pages_branch from chart-releaser action." />
-    <MESSAGE value="Enables write permissions and removes skip flags." />
-    <MESSAGE value="Update WebApp chart to 1.0.1" />
-    <MESSAGE value="Adds skip_existing flag to chart-releaser action." />
     <MESSAGE value="Bumps chart version to 1.0.1." />
     <MESSAGE value="Release WebApp chart version 2.0.0&#10;" />
     <MESSAGE value="Release WebApp chart version 2.0.0" />
@@ -491,7 +490,15 @@
     <MESSAGE value="Release" />
     <MESSAGE value="Release Vault Role Operator&#10;&#10;Adds Vault Role Operator chart to manage&#10;Vault roles.&#10;" />
     <MESSAGE value="Release Vault Role Operator&#10;&#10;Adds Vault Role Operator chart to manage&#10;Vault roles." />
-    <option name="LAST_COMMIT_MESSAGE" value="Release Vault Role Operator&#10;&#10;Adds Vault Role Operator chart to manage&#10;Vault roles." />
+    <MESSAGE value="Updates" />
+    <MESSAGE value="Updates dependency" />
+    <MESSAGE value="Updates dependency handling in CI and adds Vault Role Operator chart.&#10;" />
+    <MESSAGE value="Updates dependency handling in CI and adds Vault Role Operator chart." />
+    <MESSAGE value="Uses" />
+    <MESSAGE value="Uses `app.kubernetes.io/part-of` label instead of `app." />
+    <MESSAGE value="Uses `app.kubernetes.io/part-of` label instead of `app.k8s.io`.&#10;" />
+    <MESSAGE value="Uses `app.kubernetes.io/part-of` label instead of `app.k8s.io`." />
+    <option name="LAST_COMMIT_MESSAGE" value="Uses `app.kubernetes.io/part-of` label instead of `app.k8s.io`." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/charts/innago-vault-k8s-role-operator/templates/cluster-role-binding.yaml
+++ b/charts/innago-vault-k8s-role-operator/templates/cluster-role-binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "innago-vault-k8s-role-operator.serviceAccountName" . }}
   labels:
-    app.k8s.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   name: {{ include "innago-vault-k8s-role-operator.serviceAccountName" . }}

--- a/charts/innago-vault-k8s-role-operator/templates/cluster-role.yaml
+++ b/charts/innago-vault-k8s-role-operator/templates/cluster-role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "innago-vault-k8s-role-operator.serviceAccountName" . }}
   labels:
-    app.k8s.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
 rules:
   - verbs: ["list", "get", "watch"]
     resources: ["*"]


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use the standardized "app.kubernetes.io/part-of" label on ClusterRole and ClusterRoleBinding resources