### PR TITLE
Bump chart and app version to 2.4.2; Update Vault Role Operator ConfigMap naming

### DIFF
--- a/.idea/AICommit.xml
+++ b/.idea/AICommit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.github.blarc.ai.commits.intellij.plugin.settings.ProjectSettings">
+    <option name="splitButtonActionSelectedLLMClientId" value="4d25d59d-90ed-4814-9e2c-ad01631f2900" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="224fa381-1c18-4902-adaa-46e4f7c0975f" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-    </list>
+    <list default="true" id="224fa381-1c18-4902-adaa-46e4f7c0975f" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -108,6 +106,13 @@
     &quot;stardust.markdown.MarkdownSplitEditorSuppressor:keyList&quot;: []
   }
 }</component>
+  <component name="RunManager">
+    <configuration default="true" type="OPA_TEST_RUN_CONFIGURATION" factoryName="Opa configuration factory">
+      <option name="additionalargs" value="" />
+      <envs />
+      <method v="2" />
+    </configuration>
+  </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">
@@ -142,6 +147,7 @@
       <workItem from="1755852588980" duration="2447000" />
       <workItem from="1756097072597" duration="7641000" />
       <workItem from="1756112789900" duration="1476000" />
+      <workItem from="1758228377846" duration="312000" />
     </task>
     <task id="LOCAL-00001" summary="cronjob - fix schedule quoting&#10;docs - use helm-docs utility to generate chart readme">
       <option name="closed" value="true" />
@@ -479,7 +485,15 @@
       <option name="project" value="LOCAL" />
       <updated>1756113568940</updated>
     </task>
-    <option name="localTasksCounter" value="43" />
+    <task id="LOCAL-00043" summary="Bump chart and app version to 2.4.1; Add ArgoCD sync annotation to Vault Role Operator config map">
+      <option name="closed" value="true" />
+      <created>1758228572973</created>
+      <option name="number" value="00043" />
+      <option name="presentableId" value="LOCAL-00043" />
+      <option name="project" value="LOCAL" />
+      <updated>1758228572973</updated>
+    </task>
+    <option name="localTasksCounter" value="44" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -500,7 +514,6 @@
   </component>
   <component name="VcsManagerConfiguration">
     <option name="CLEAR_INITIAL_COMMIT_MESSAGE" value="true" />
-    <MESSAGE value="B" />
     <MESSAGE value="Bumps chart and app version to 2.0.2.&#10;" />
     <MESSAGE value="Bumps chart and app version to 2.0.2." />
     <MESSAGE value="Adds" />
@@ -522,10 +535,11 @@
     <MESSAGE value="Updates" />
     <MESSAGE value="Updates chart to 2.4.0 and integrates Innago vault operator.&#10;" />
     <MESSAGE value="Updates chart to 2.4.0 and integrates Innago vault operator." />
+    <MESSAGE value="fix port number; Configure security context and Keptn annotations" />
     <MESSAGE value="Configure" />
     <MESSAGE value="Configure security context and Keptn annotations&#10;" />
-    <MESSAGE value="fix port number; Configure security context and Keptn annotations" />
-    <option name="LAST_COMMIT_MESSAGE" value="fix port number; Configure security context and Keptn annotations" />
+    <MESSAGE value="Bump chart and app version to 2.4.1; Add ArgoCD sync annotation to Vault Role Operator config map" />
+    <option name="LAST_COMMIT_MESSAGE" value="Bump chart and app version to 2.4.1; Add ArgoCD sync annotation to Vault Role Operator config map" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: webapp
 description: Innago Helm chart for a WebApp in Kubernetes
 type: application
-version: 2.4.1
-appVersion: "2.4.1"
+version: 2.4.2
+appVersion: "2.4.2"
 icon: https://cncf-branding.netlify.app/img/projects/helm/icon/color/helm-icon-color.png

--- a/charts/webapp/templates/innago-vault-k8s-role-operator-cm.yaml
+++ b/charts/webapp/templates/innago-vault-k8s-role-operator-cm.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  generateName: {{ include "WebApp.fullname" . | lower | trunc 50 }}-vault-
+  name: {{ include "WebApp.fullname" . | lower | trunc 50 }}-vault-{{ randAlphaNum 5 | lower }}
   namespace: {{ .Release.Namespace }}
   annotations:
     innago.com/vault-k8s-role: ""


### PR DESCRIPTION
## Summary by Sourcery

Bump Helm chart and application version to 2.4.2 and update Vault Role Operator ConfigMap naming strategy

Enhancements:
- Update Helm chart and appVersion fields to 2.4.2
- Switch Vault Role Operator ConfigMap from generateName to explicit name with random suffix

Chores:
- Remove IDE workspace XML and add AICommit configuration